### PR TITLE
Split emacs and non-emacs tests, run in parallel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
 
     - name: Run tests with bats
       run: |
-        docker exec test_container sh -c "cd /home/tester/src/tests && ./run_tests.bats"
+        docker exec test_container sh -c "cd /home/tester/src/tests && bats *.bats --report-formatter tap -j 4"
 
     - name: Copy test output
       if: success() || failure()

--- a/containers/alpine
+++ b/containers/alpine
@@ -7,6 +7,7 @@ RUN apk add --no-cache \
     fish \
     git \
     ncurses \
+    parallel \
     py3-pip \
     shellcheck \
     stow

--- a/tests/emacs_tests.bats
+++ b/tests/emacs_tests.bats
@@ -1,0 +1,19 @@
+#! /usr/bin/env -S bats --report-formatter tap
+
+setup_file() {
+    # One-time setup: start the emacs daemon
+    emacs --daemon=test
+}
+
+@test "magit available" {
+      emacsclient -s test -e "(magit-version)"
+}
+
+@test "ace-window available" {
+      emacsclient -s test -e "(ace-window t)"
+}
+
+teardown_file() {
+    # Kill the emacs daemon
+    emacs --batch --exec "(progn (require 'server) (server-eval-at \"test\" '(kill-emacs)))"               
+}

--- a/tests/other_tests.bats
+++ b/tests/other_tests.bats
@@ -1,18 +1,5 @@
 #! /usr/bin/env -S bats --report-formatter tap
 
-setup_file() {
-    # One-time setup: start the emacs daemon
-    emacs --daemon=test
-}
-
-@test "magit available" {
-      emacsclient -s test -e "(magit-version)"
-}
-
-@test "ace-window available" {
-      emacsclient -s test -e "(ace-window t)"
-}
-
 @test "valid TOML files" {
       find . -name "*.toml" | xargs toml-validator
 }
@@ -26,9 +13,4 @@ setup_file() {
 
 @test "fish: check syntax of .fish files" {
     find -XL ~/.config -name '*.fish' | xargs -n 1 fish --no-execute
-}
-
-teardown_file() {
-    # Kill the emacs daemon
-    emacs --batch --exec "(progn (require 'server) (server-eval-at \"test\" '(kill-emacs)))"               
 }


### PR DESCRIPTION
At the moment test time is dominated by emacs setup so this won't have a big impact on walltime. But it means we can be a bit more relaxed about adding a lot more tests 😄 