### PR TITLE
improved emacsclient launch function

### DIFF
--- a/dotfiles.org
+++ b/dotfiles.org
@@ -724,14 +724,35 @@ corresponding section of Bash config for more info.
   if status is-interactive
       # Commands to run in interactive sessions can go here
 
-      if test -f "/usr/lib64/libc_malloc_debug.so.0"
-          set -x EDITOR="LD_PRELOAD=/usr/lib64/libc_malloc_debug.so.0 emacsclient -t"
-      else
-          set -x EDITOR "emacsclient -t"
+      set -x ALTERNATE_EDITOR ''
+
+      function em
+          set -l PRELOAD_LIB /usr/lib/libc_malloc_debug.so
+          set -l EC_ARGS -t
+
+          if set -q INSIDE_EMACS
+              and not set -q EMACS_SERVER_NAME
+              echo "em: EMACS_SERVER_NAME not set" >&2
+              return 1
+          end
+
+          if set -q EMACS_SERVER_NAME
+              set -a EC_ARGS -s $EMACS_SERVER_NAME
+          end
+
+          if set -q INSIDE_EMACS
+              set -a EC_ARGS -n
+          end
+
+          if test -e $PRELOAD_LIB
+              env LD_PRELOAD=$PRELOAD_LIB emacsclient $EC_ARGS $argv
+          else
+              emacsclient $EC_ARGS $argv
+          end
       end
 
-      set -x ALTERNATE_EDITOR ''
-      alias em $EDITOR
+      set -x EDITOR em
+
   end
 #+end_src
 

--- a/dotfiles.org
+++ b/dotfiles.org
@@ -720,39 +720,47 @@ colors:
 
 Emacs can require a workaround to deal with glibc incompatibility; see
 corresponding section of Bash config for more info.
+#+begin_src fish :tangle "fish/.local/bin/em_wrap" :mkdirp yes :shebang "#! /usr/bin/env fish"
+  set -x ALTERNATE_EDITOR ''
+
+  function em
+      set -l PRELOAD_LIB /usr/lib/libc_malloc_debug.so
+      set -l EC_ARGS
+
+      if set -q INSIDE_EMACS
+          and not set -q EMACS_SERVER_NAME
+          echo "em: EMACS_SERVER_NAME not set" >&2
+          return 1
+      end
+
+      if set -q EMACS_SERVER_NAME
+          set -a EC_ARGS -s $EMACS_SERVER_NAME
+      end
+
+      if not set -q INSIDE_EMACS
+          if isatty stdin
+              set -a EC_ARGS -t
+          else
+              set -a EC_ARGS -c  # GUI frame fallback
+          end
+      end
+
+      if test -e $PRELOAD_LIB
+          env LD_PRELOAD=$PRELOAD_LIB emacsclient $EC_ARGS $argv
+      else
+          emacsclient $EC_ARGS $argv
+      end
+  end
+
+  em $argv
+#+end_src
+
 #+begin_src fish
   if status is-interactive
       # Commands to run in interactive sessions can go here
 
-      set -x ALTERNATE_EDITOR ''
-
-      function em
-          set -l PRELOAD_LIB /usr/lib/libc_malloc_debug.so
-          set -l EC_ARGS -t
-
-          if set -q INSIDE_EMACS
-              and not set -q EMACS_SERVER_NAME
-              echo "em: EMACS_SERVER_NAME not set" >&2
-              return 1
-          end
-
-          if set -q EMACS_SERVER_NAME
-              set -a EC_ARGS -s $EMACS_SERVER_NAME
-          end
-
-          if set -q INSIDE_EMACS
-              set -a EC_ARGS -n
-          end
-
-          if test -e $PRELOAD_LIB
-              env LD_PRELOAD=$PRELOAD_LIB emacsclient $EC_ARGS $argv
-          else
-              emacsclient $EC_ARGS $argv
-          end
-      end
-
-      set -x EDITOR em
-
+      set -x EDITOR ~/.local/bin/em_wrap
+      alias em ~/.local/bin/em_wrap
   end
 #+end_src
 

--- a/emacs.org
+++ b/emacs.org
@@ -163,6 +163,8 @@ Set up a server for emacsclient and export the name to subshells so we
 can find it from terminals (instead of opening a sub-emacs!)
 #+begin_src elisp
   (require 'server)
+  (if (display-graphic-p)
+      (setq server-name "gui-server"))
   (unless (server-running-p)
     (server-start))
   (setenv "EMACS_SERVER_NAME" server-name)


### PR DESCRIPTION
The main requirement for this is to avoid messy situations if I instintively "em" while inside an emacs vterm. Nested emacs instances are not nice, instead this should jump to existing (outer) emacs.

Currently there are some rough corners:
- if TUI and GUI are both open, sometimes vterm->em from TUI opens in GUI instead

- other programs using EDITOR don't expect/like this to be a fish function.